### PR TITLE
Enable per-request exclusion rules via :exclude Proc

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,19 @@ config.middleware.use Rack::HostRedirect, {
 When specifying a URI methods hash, the ```:host``` key is required; all other URI keys are optional.
 
 
+Let's Encrypt and custom exclusion rules
+---
+
+This middleware will redirect all requests to a host specified as a key in the configuration, but if you need certain exclusions to this -- e.g. you're handling a Let's Encrypt challenge request in your app, so you want to let that go through, and redirect everything else -- you can do so via passing in a Proc to the ```:exclude``` key:
+
+```ruby
+# Allow ACME challenge request to pass through, redirect everything else:
+config.middleware.use Rack::HostRedirect, {
+  'www.example.com' => {host: 'example.com', exclude: ->(request) {request.path.start_with?('/.well-known/acme-challenge/')}}
+}
+```
+
+
 With ActionDispatch::SSL
 ------------------------
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ config.middleware.use Rack::HostRedirect, {
 When specifying a URI methods hash, the ```:host``` key is required; all other URI keys are optional.
 
 
-Let's Encrypt and custom exclusion rules
+Overriding the redirect per-request
 ---
 
 This middleware will redirect all requests to a host specified as a key in the configuration, but if you need certain exclusions to this -- e.g. you're handling a Let's Encrypt challenge request in your app, so you want to let that go through, and redirect everything else -- you can do so via passing in a Proc to the ```:exclude``` key:
@@ -74,7 +74,10 @@ This middleware will redirect all requests to a host specified as a key in the c
 ```ruby
 # Allow ACME challenge request to pass through, redirect everything else:
 config.middleware.use Rack::HostRedirect, {
-  'www.example.com' => {host: 'example.com', exclude: ->(request) {request.path.start_with?('/.well-known/acme-challenge/')}}
+  'www.example.com' => {
+    host: 'example.com', 
+    exclude: -> (request) { request.path.start_with?('/.well-known/acme-challenge/') }
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ config.middleware.use Rack::HostRedirect, {
 When specifying a URI methods hash, the ```:host``` key is required; all other URI keys are optional.
 
 
-Overriding the redirect per-request
+Skip redirect for special cases (e.g. Let's Encrypt)
 ---
 
-This middleware will redirect all requests to a host specified as a key in the configuration, but if you need certain exclusions to this -- e.g. you're handling a Let's Encrypt challenge request in your app, so you want to let that go through, and redirect everything else -- you can do so via passing in a Proc to the ```:exclude``` key:
+When you specify a host redirect, it will redirect all requests to that host, but if you need certain exclusions to this -- e.g. you're handling a Let's Encrypt challenge request in your app, so you need to let that pass through -- you can do so via passing in a Proc to the ```:exclude``` key:
 
 ```ruby
 # Allow ACME challenge request to pass through, redirect everything else:
@@ -80,6 +80,8 @@ config.middleware.use Rack::HostRedirect, {
   }
 }
 ```
+
+The proc will be called for each request with the ```Rack::Request``` object. If the proc returns a truthy value, the request will pass through without a redirect.
 
 
 With ActionDispatch::SSL


### PR DESCRIPTION
Example:

```ruby
# Allow ACME challenge request to pass through, redirect everything else:
config.middleware.use Rack::HostRedirect, {
  'www.example.com' => {
    host: 'example.com', 
    exclude: -> (request) { request.path.start_with?('/.well-known/acme-challenge/') }
  }
}
```